### PR TITLE
:bug:마이페이지, 피드 Input등 버그수정

### DIFF
--- a/client/src/components/header/Header.tsx
+++ b/client/src/components/header/Header.tsx
@@ -65,11 +65,18 @@ const Header: React.FC = () => {
           <Link to="/petmap">
             <MapButtonStyle />
           </Link>
-          <Link to="/create">
-            <CreateFeedButtonStyle />
+          <Link to={loginState ? "/create" : ""}>
+            <CreateFeedButtonStyle
+              onClick={() =>
+                loginState ? undefined : alert("로그인이 필요합니다.")
+              }
+            />
           </Link>
-
-          <NotificationsContainer onClick={convertToRead}>
+          <NotificationsContainer
+            onClick={() =>
+              loginState ? convertToRead : alert("로그인이 필요합니다.")
+            }
+          >
             {isRead === false ? <RedPointStyle /> : <NotificationsStyle />}
           </NotificationsContainer>
         </MiddleButtonContainer>

--- a/client/src/components/signUpElement/SignUpInputs.tsx
+++ b/client/src/components/signUpElement/SignUpInputs.tsx
@@ -22,6 +22,7 @@ import {
 const SignUpInputs = () => {
   const {
     register,
+    handleSubmit,
     formState: { errors },
     setValue,
     watch,
@@ -94,11 +95,7 @@ const SignUpInputs = () => {
         회원가입을 위해
         <br /> 정보를 입력해 주세요.
       </h2>
-      <form
-        onSubmit={(e) => {
-          e.preventDefault();
-        }}
-      >
+      <form onSubmit={handleSubmit(onSubmit)}>
         <div>
           <TextInput>
             <MessageIcon />
@@ -107,6 +104,12 @@ const SignUpInputs = () => {
               placeholder="이메일을 입력해주세요."
               autoComplete="off"
               {...register("email", { required: true, pattern: emailRegex })}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") {
+                  e.preventDefault();
+                  emailMutate();
+                }
+              }}
             />
             <button onClick={() => emailMutate()}>인증번호 전송</button>
           </TextInput>
@@ -124,6 +127,12 @@ const SignUpInputs = () => {
               placeholder="인증번호를 입력해주세요."
               autoComplete="off"
               {...register("authentication", { required: true })}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") {
+                  e.preventDefault();
+                  codeMutate();
+                }
+              }}
             />
             <button onClick={() => codeMutate()}>인증하기</button>
           </TextInput>
@@ -136,6 +145,12 @@ const SignUpInputs = () => {
               placeholder="닉네임을 입력해주세요."
               autoComplete="off"
               {...register("nickname", { required: true })}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") {
+                  e.preventDefault();
+                  nicknameMutate();
+                }
+              }}
             />
             <button onClick={() => nicknameMutate()}>중복확인</button>
           </TextInput>
@@ -170,7 +185,7 @@ const SignUpInputs = () => {
               autoComplete="off"
               {...register("pwConfirm", {
                 required: true,
-                validate: (value) => value === password || "",
+                validate: (value) => value === password,
               })}
             />
           </TextInput>
@@ -207,9 +222,7 @@ const SignUpInputs = () => {
             </ErrorMsg>
           )}
         </CheckBoxContainer>
-        <SubmitButton type="submit" onClick={onSubmit}>
-          가입하기
-        </SubmitButton>
+        <SubmitButton type="submit">가입하기</SubmitButton>
       </form>
     </InputContainer>
   );

--- a/client/src/components/userInfo/UserInfoForm.tsx
+++ b/client/src/components/userInfo/UserInfoForm.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { useRecoilValue } from "recoil";
 import { memberIdAtom, tokenAtom } from "../../atoms";
@@ -98,7 +98,9 @@ const MyInfoForm: React.FC<MyInfoFormProps> = ({ pageMemberId }) => {
           img={data?.data.image}
         />
       )}
-      {lostPw && <PasswordChangeForm setLostPw={setLostPw} />}
+      {lostPw && (
+        <PasswordChangeForm setLostPw={setLostPw} email={data.data.email} />
+      )}
     </MyInfoContainer>
   );
 };

--- a/client/src/components/userInfo/infoChangeComponent/PasswordChange.style.tsx
+++ b/client/src/components/userInfo/infoChangeComponent/PasswordChange.style.tsx
@@ -26,6 +26,7 @@ export const ChangeForm = styled.div`
   form {
     width: 100%;
     height: 100%;
+    margin-top: 10%;
     display: flex;
     flex-direction: column;
     align-items: center;
@@ -53,7 +54,7 @@ export const ChangeContainer = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
-  justify-content: space-around;
+  justify-content: flex-start;
   .submitButton {
     width: 30%;
     color: black;
@@ -72,5 +73,5 @@ export const BackIcon = styled(Backspace)`
 
 export const MiddleBox = styled.div`
   width: 70%;
-  height: 300px;
+  height: 70%;
 `;

--- a/client/src/components/userInfo/infoChangeComponent/PasswordChange.tsx
+++ b/client/src/components/userInfo/infoChangeComponent/PasswordChange.tsx
@@ -17,23 +17,32 @@ import {
   usePatchUserPassword,
 } from "../../../hooks/UserInfoHook";
 
-const PasswordChangeForm: React.FC<{
+type PasswordChangeProps = {
   setLostPw: React.Dispatch<React.SetStateAction<boolean>>;
-}> = ({ setLostPw }) => {
+  email?: string;
+};
+
+const PasswordChangeForm: React.FC<PasswordChangeProps> = ({
+  setLostPw,
+  email,
+}) => {
   const {
     register,
+    handleSubmit,
     formState: { errors },
     watch,
   } = useForm();
   //각각 input 태그 value 호출
-  const email = watch("email", "");
+  const emailValue = watch("email", "");
   const authentication = watch("authentication", "");
   const password = watch("password", "");
   const pwConfirm = watch("pwConfirm", "");
   const [codeCheck, setCodeCheck] = useState<boolean>(false);
-  const { mutate: postEmailMutate } = usePostUserEmail(email);
+  const { mutate: postEmailMutate } = usePostUserEmail(
+    email ? email : emailValue,
+  );
   const { mutate: postCodeMutate } = usePostUserCode(
-    email,
+    emailValue,
     authentication,
     setCodeCheck,
   );
@@ -41,7 +50,9 @@ const PasswordChangeForm: React.FC<{
     password,
     pwConfirm,
   );
-
+  const onSubmit = () => {
+    patchPasswordMutate();
+  };
   //이메일 유효성
   const emailRegex =
     /^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*$/;
@@ -60,22 +71,25 @@ const PasswordChangeForm: React.FC<{
           <h3>비밀번호변경</h3>
         </Topbox>
         <MiddleBox>
-          <form
-            onSubmit={(e) => {
-              e.preventDefault();
-            }}
-          >
+          <form onSubmit={handleSubmit(onSubmit)}>
             <div>
               <TextInput>
                 <Message />
                 <input
                   type="text"
-                  placeholder="이메일을 입력해주세요."
+                  value={email && email}
+                  placeholder="이메일을 입력해주세요"
                   autoComplete="off"
                   {...register("email", {
                     required: true,
                     pattern: emailRegex,
                   })}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter") {
+                      e.preventDefault();
+                      postEmailMutate();
+                    }
+                  }}
                 />
                 <button onClick={() => postEmailMutate()}>인증번호 전송</button>
               </TextInput>
@@ -93,6 +107,12 @@ const PasswordChangeForm: React.FC<{
                   placeholder="인증번호를 입력해주세요."
                   autoComplete="off"
                   {...register("authentication", { required: true })}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter") {
+                      e.preventDefault();
+                      postCodeMutate();
+                    }
+                  }}
                 />
                 <button onClick={() => postCodeMutate()}>인증하기</button>
               </TextInput>
@@ -108,9 +128,14 @@ const PasswordChangeForm: React.FC<{
                     required: true,
                     pattern: passwordRegex,
                   })}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter") {
+                      e.preventDefault();
+                    }
+                  }}
                 />
               </TextInput>
-              {errors.pwConfirm && (
+              {errors.password && (
                 <ErrorMsg>
                   <p>
                     비밀번호는 숫자 + 문자 + 특수문자 조합 8자 이상이어야
@@ -128,9 +153,13 @@ const PasswordChangeForm: React.FC<{
                   autoComplete="off"
                   {...register("pwConfirm", {
                     required: true,
-                    validate: (value) =>
-                      value === password || "비밀번호가 일치하지 않습니다.",
+                    validate: (value) => value === password,
                   })}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter") {
+                      e.preventDefault();
+                    }
+                  }}
                 />
               </TextInput>
               {errors.pwConfirm && (
@@ -139,14 +168,11 @@ const PasswordChangeForm: React.FC<{
                 </ErrorMsg>
               )}
             </div>
+            <button className="submitButton" type="submit">
+              비밀번호 변경하기
+            </button>
           </form>
         </MiddleBox>
-        <button
-          className="submitButton"
-          onClick={codeCheck ? () => patchPasswordMutate() : undefined}
-        >
-          비밀번호 변경하기
-        </button>
       </ChangeContainer>
     </ChangeForm>
   );

--- a/client/src/components/userInfo/infoChangeComponent/ProfileChange.style.tsx
+++ b/client/src/components/userInfo/infoChangeComponent/ProfileChange.style.tsx
@@ -67,10 +67,12 @@ export const ChangeContainer = styled.div`
 export const Topbox = styled.div`
   width: 100%;
   display: flex;
-  justify-content: space-around;
+  justify-content: flex-start;
   align-items: center;
+  position: relative;
   h3 {
-    padding: 0 15%;
+    padding: 3% 0;
+    margin: 0 auto;
   }
 `;
 
@@ -79,11 +81,17 @@ export const ProfileBox = styled.div`
   height: 300px;
   display: flex;
   flex-direction: column;
-  justify-content: space-around;
+  justify-content: flex-start;
+  gap: 10px;
   align-items: center;
+  position: relative;
   & > div {
     width: 200px;
     height: 200px;
+  }
+  & > button {
+    position: absolute;
+    bottom: 0;
   }
 `;
 export const ProfileImg = styled.div<{ thumbnail: string | undefined }>`
@@ -123,7 +131,9 @@ export const TextInput = styled.div`
   }
 `;
 //---------아이콘
-export const BackIcon = styled(Backspace)``;
+export const BackIcon = styled(Backspace)`
+  position: absolute;
+`;
 export const PersonIcon = styled(Person)`
   width: 18px;
   height: 18px;

--- a/client/src/components/userInfo/infoChangeComponent/ProfileChange.tsx
+++ b/client/src/components/userInfo/infoChangeComponent/ProfileChange.tsx
@@ -44,6 +44,7 @@ const ProfileChange: React.FC<ChageData> = ({
   const handleModal = () => {
     setChangeInfo(false);
   };
+  const token = useRecoilValue(tokenAtom);
 
   const uploadImg = (e: ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files && e.target.files[0];
@@ -53,15 +54,16 @@ const ProfileChange: React.FC<ChageData> = ({
       setImageFiles({ file: file, name: name, type: type });
     }
   };
-  const token = useRecoilValue(tokenAtom);
   const handelChange = async () => {
     await getPresignedUrl(imageFiles.name).then((res) => {
       uploadToS3(res, imageFiles.file, imageFiles.type).then((res) => {
         if (res.config.url) {
           imgURL = res.config.url.substring(0, res.config.url.indexOf("?"));
-          patchProfileImg(imgURL, token).then(() => {
-            queryClient.invalidateQueries({ queryKey: ["userInfo"] });
-          });
+          if (imgURL) {
+            patchProfileImg(imgURL, token).then(() => {
+              queryClient.invalidateQueries({ queryKey: ["userInfo"] });
+            });
+          }
         }
       });
     });
@@ -84,16 +86,6 @@ const ProfileChange: React.FC<ChageData> = ({
         <Topbox>
           <BackIcon onClick={handleModal} />
           <h3>프로필 설정</h3>
-          <button
-            className="submitButton"
-            onClick={() => {
-              imgURL !== ""
-                ? handelChange
-                : alert("변경된 프로필 이미지가 없습니다.");
-            }}
-          >
-            완료
-          </button>
         </Topbox>
         <ProfileBox>
           <AttachingInput
@@ -112,9 +104,12 @@ const ProfileChange: React.FC<ChageData> = ({
           ) : (
             <UserImgForm width={100} height={100} radius={50} URL={img} />
           )}
-          <ChangeImgButton htmlFor="add_image">
-            프로필사진 바꾸기
-          </ChangeImgButton>
+          <ChangeImgButton htmlFor="add_image">프로필사진 선택</ChangeImgButton>{" "}
+          {imageFiles.file !== null && (
+            <button className="submitButton" onClick={handelChange}>
+              변경하기
+            </button>
+          )}
         </ProfileBox>
         <InputBox>
           <form

--- a/client/src/components/userInfo/petComponent/PetAddForm.tsx
+++ b/client/src/components/userInfo/petComponent/PetAddForm.tsx
@@ -113,7 +113,7 @@ const PetAddForm: React.FC = () => {
               여자
               <input
                 type="radio"
-                value="FEMAIL"
+                value="FEMALE"
                 {...register("gender", { required: true })}
               />
             </label>

--- a/client/src/hooks/FeedHook.ts
+++ b/client/src/hooks/FeedHook.ts
@@ -161,6 +161,7 @@ export const useFeedLike = (
       alert("피드 좋아요 성공");
       queryClient.invalidateQueries({ queryKey: ["Feeds"] });
       queryClient.invalidateQueries({ queryKey: ["Feed"] });
+      queryClient.invalidateQueries({ queryKey: ["userFeed"] });
       successFunc && successFunc();
       return;
     },
@@ -189,6 +190,7 @@ export const useFeedBookmark = (
       alert("피드 북마크 성공");
       queryClient.invalidateQueries({ queryKey: ["Feeds"] });
       queryClient.invalidateQueries({ queryKey: ["Feed"] });
+      queryClient.invalidateQueries({ queryKey: ["userFeed"] });
       successFunc && successFunc();
       return;
     },

--- a/client/src/services/userInfoService.tsx
+++ b/client/src/services/userInfoService.tsx
@@ -74,10 +74,14 @@ export const postUserCode = async (email: string, authNum: number) => {
 export const patchUserPassword = async (
   password: string,
   pwConfirm: string,
+  token: string,
 ) => {
+  const headers = {
+    headers: { Authorization: token },
+  };
   const requestObj = { password: password, pwConfirm: pwConfirm };
   const url = `${ROOT_URL}/member/update/password`;
-  const res = await axios.patch(url, requestObj);
+  const res = await axios.patch(url, requestObj, headers);
   return res;
 };
 


### PR DESCRIPTION
## 💡 Motivation
12/30 기능테스트 후 나온 버그 수정


## 🔑 Key Changes
수정 완료 목록

- 비밀번호 변경시 이메일은 그 유저의 이메일을 고정시켜놓고 사용하기
- 프로필 사진 이미지가 안바뀜
- 다른 input 에서 enter를 누르면 인증번호 전송이 됨
- 마이페이지(게시물이 없을경우) 무한요청 들어감
- 피드리스트 에서 좋아요, 북마크 해제하면 query 실행
- 헤더에서 비로그인시 creat 막기
- 마이페이지 - 닉네임 변경시 이미 존재하는 닉네임이면 alert 띄우기

## 🗣️ To Reviewers
추후 수정 목록

- 2시간후 세션스토리지 초기화, 로그인 페이지로 이동
- 회원가입시 이메일로 인증번호 전송 눌렀을때 이미 가입된 아이디인지 response 받기로함
