### PR TITLE
🐛 : 12/30 1차 오류 수정

### DIFF
--- a/client/src/components/petFeed/FeedComment.tsx
+++ b/client/src/components/petFeed/FeedComment.tsx
@@ -69,13 +69,13 @@ const FeedComment: React.FC<OwnProps> = ({ replyId }) => {
           onChange={handleWriteComment}
           onKeyUp={handlePostComment}
         />
-        <AddBtn>게시</AddBtn>
+        <AddBtn onClick={() => postComment()}>게시</AddBtn>
       </AddBox>
       {commentsData?.map((comment: feedCommentType) => (
         <CommentItem key={comment.commentId} comment={comment} />
       ))}
       {moreComments && <div ref={setTarget} />}
-      {hasNextPage && (
+      {commentsData && commentsData.length > 0 && hasNextPage && (
         <button onClick={() => setMoreComments(true)}>답글 더보기</button>
       )}
     </Comments>

--- a/client/src/components/petFeed/FeedDetail.tsx
+++ b/client/src/components/petFeed/FeedDetail.tsx
@@ -25,7 +25,6 @@ import {
   Profile,
   ProfileBox,
   ProfileImg,
-  Replies,
   ReviewCount,
   RightDetail,
   RightScroll,
@@ -35,7 +34,6 @@ import {
   UploadTime,
   UserName,
 } from "./Feed.Style";
-import FeedReply from "./FeedReply";
 import Heart from "../../atoms/button/Heart";
 import Bookmark from "../../atoms/button/Bookmark";
 import Dropdown from "../../atoms/dropdown/Dropdowns";
@@ -211,7 +209,7 @@ const FeedDetail: React.FC<OwnProps> = ({ feedId, handleMoreReview }) => {
           </FeedHeader>
           <FeedContents>
             <FeedTitle>{data.title}</FeedTitle>
-            <FeedContent>{data.content}</FeedContent>
+            <FeedContent dangerouslySetInnerHTML={{ __html: data.content }} />
           </FeedContents>
           {(data.images.length > 0 || data.videos) && (
             <FeedDetailMedia>
@@ -274,7 +272,7 @@ const FeedDetail: React.FC<OwnProps> = ({ feedId, handleMoreReview }) => {
               댓글 {data.replies.pageInformation.totalSize}개
             </ReviewCount>
           </FeedReviewTop>
-          <FeedReplies feedId={feedId} />
+          <FeedReplies feedId={feedId} feedOwnerId={data.member.memberId} />
           {/* <Replies>
             {data.replies.replies.map((reply: any) => (
               <FeedReply key={reply.replyId} reply={reply} />

--- a/client/src/components/petFeed/FeedList.tsx
+++ b/client/src/components/petFeed/FeedList.tsx
@@ -62,9 +62,8 @@ const FeedList: React.FC<OwnProps> = ({ items }) => {
   const feedDate = createDate.split("-").map((el) => parseInt(el));
   const createTime = items.createdDate.split("T")[1];
   const feedTime = createTime.split(":").map((el) => parseInt(el));
-  const feedId = items.feedId;
-  const { mutate: feedLike } = useFeedLike(feedId, accesstoken);
-  const { mutate: feedBookmark } = useFeedBookmark(feedId, accesstoken);
+  const { mutate: feedLike } = useFeedLike(items.feedId, accesstoken);
+  const { mutate: feedBookmark } = useFeedBookmark(items.feedId, accesstoken);
 
   const handleMoreReview = (): void => setDetail(!isDetail);
   const handleSetting = (): void => setSetting(!isSetting);
@@ -115,7 +114,7 @@ const FeedList: React.FC<OwnProps> = ({ items }) => {
 
   // 피드 수정 (핸들러)
   const handleReplyPatch = () => {
-    navigator(`/update/${feedId}`);
+    navigator(`/update/${items.feedId}`);
   };
 
   // 설정 드롭다운 버튼 종류 및 핸들러 연결
@@ -210,7 +209,6 @@ const FeedList: React.FC<OwnProps> = ({ items }) => {
           <RightScroll onClick={() => handleScrollRight()} />
         </FeedMedia>
       )}
-
       <FeedStatus>
         <LikeBox>
           <Heart

--- a/client/src/components/petFeed/FeedReplies.tsx
+++ b/client/src/components/petFeed/FeedReplies.tsx
@@ -3,6 +3,8 @@ import { useInfiniteGetReplies } from "../../hooks/ReplyHook";
 import { Replies } from "./Feed.Style";
 import FeedReply from "./FeedReply";
 import useIntersectionObserver from "../../hooks/useIntersectionObserver";
+import { useRecoilValue } from "recoil";
+import { tokenAtom } from "../../atoms";
 
 interface OwnProps {
   feedId: number;
@@ -10,10 +12,11 @@ interface OwnProps {
 }
 
 const FeedReplies: React.FC<OwnProps> = ({ feedId, feedOwnerId }) => {
+  const accesstoken = useRecoilValue(tokenAtom);
   const [moreReplies, setMoreReplies] = useState(false);
   const callbackFn = () => setMoreReplies(false);
   const { data, isLoading, isError, fetchNextPage, hasNextPage } =
-    useInfiniteGetReplies(feedId);
+    useInfiniteGetReplies(feedId, accesstoken);
   const repliesData = data?.pages.flat();
 
   const { setTarget } = useIntersectionObserver({

--- a/client/src/components/petFeed/FeedReplies.tsx
+++ b/client/src/components/petFeed/FeedReplies.tsx
@@ -6,9 +6,10 @@ import useIntersectionObserver from "../../hooks/useIntersectionObserver";
 
 interface OwnProps {
   feedId: number;
+  feedOwnerId: number;
 }
 
-const FeedReplies: React.FC<OwnProps> = ({ feedId }) => {
+const FeedReplies: React.FC<OwnProps> = ({ feedId, feedOwnerId }) => {
   const [moreReplies, setMoreReplies] = useState(false);
   const callbackFn = () => setMoreReplies(false);
   const { data, isLoading, isError, fetchNextPage, hasNextPage } =
@@ -30,7 +31,11 @@ const FeedReplies: React.FC<OwnProps> = ({ feedId }) => {
   return (
     <Replies>
       {repliesData?.map((reply: any) => (
-        <FeedReply key={reply.replyId} reply={reply} />
+        <FeedReply
+          key={reply.replyId}
+          reply={reply}
+          feedOwnerId={feedOwnerId}
+        />
       ))}
       {moreReplies && <div ref={setTarget}></div>}
       {repliesData && repliesData.length > 0 && hasNextPage && (

--- a/client/src/components/petFeed/FeedReply.tsx
+++ b/client/src/components/petFeed/FeedReply.tsx
@@ -37,9 +37,10 @@ import {
 
 interface OwnProps {
   reply: any;
+  feedOwnerId: number;
 }
 
-const FeedReply: React.FC<OwnProps> = ({ reply }) => {
+const FeedReply: React.FC<OwnProps> = ({ reply, feedOwnerId }) => {
   const isLogin = useRecoilValue(isLoginAtom);
   const accesstoken = useRecoilValue(tokenAtom);
   const setAlertModal = useSetRecoilState(alertAtom);
@@ -64,7 +65,12 @@ const FeedReply: React.FC<OwnProps> = ({ reply }) => {
   const handleComment = (): void => setComment(!isComment);
   const handleCloseDropdown = () => setSetting(false);
   const handleEditReply = () => setEditReply(true);
-  const handleReplyDelete = () => deleteReply();
+  const handleReplyDelete = () => {
+    if (reply.fix) {
+      return setAlertModal("고정된 댓글은 삭제할 수 없습니다.");
+    }
+    deleteReply();
+  };
   const handleReplyFix = () => replyfix();
   const handleChangeReply = (e: React.ChangeEvent<HTMLInputElement>) =>
     setContent(e.target.value);
@@ -89,9 +95,19 @@ const FeedReply: React.FC<OwnProps> = ({ reply }) => {
   const myId = useRecoilValue(memberIdAtom);
   const settingContent =
     reply?.member.memberId === myId
+      ? feedOwnerId === myId
+        ? {
+            수정하기: handleEditReply,
+            삭제하기: handleReplyDelete,
+            댓글고정: handleReplyFix,
+          }
+        : {
+            수정하기: handleEditReply,
+            삭제하기: handleReplyDelete,
+          }
+      : feedOwnerId === myId
       ? {
-          수정하기: handleEditReply,
-          삭제하기: handleReplyDelete,
+          신고하기: handleReplyReport,
           댓글고정: handleReplyFix,
         }
       : {

--- a/client/src/hooks/CommentHook.ts
+++ b/client/src/hooks/CommentHook.ts
@@ -58,6 +58,7 @@ export const usePostComment = (
       console.log(res);
       alert("대댓글 등록 완료");
       queryClient.invalidateQueries({ queryKey: ["comment"] });
+      queryClient.invalidateQueries({ queryKey: ["Replies"] });
       successFunc && successFunc();
       return;
     },

--- a/client/src/hooks/FeedHook.ts
+++ b/client/src/hooks/FeedHook.ts
@@ -30,11 +30,11 @@ import { useNavigate } from "react-router-dom";
 // };
 
 // 피드 전체 조회 (무한스크롤)
-export const useInfiniteGetFeeds = () => {
+export const useInfiniteGetFeeds = (accesstoken: string) => {
   return useInfiniteQuery({
-    queryKey: ["Feeds"],
+    queryKey: ["Feeds", accesstoken],
     queryFn: async ({ pageParam = 1 }) => {
-      const response = await getFeeds(pageParam);
+      const response = await getFeeds(pageParam, accesstoken);
       return response;
     },
     getNextPageParam: (lastPage, allPages) => {

--- a/client/src/hooks/FeedHook.ts
+++ b/client/src/hooks/FeedHook.ts
@@ -18,16 +18,16 @@ import { enrollMapType } from "../types/mapType";
 import { usePostMap } from "./MapHooks";
 import { useNavigate } from "react-router-dom";
 
-// 피드 전체 조회
-export const useGetFeeds = (page: number) => {
-  return useQuery({
-    queryKey: ["Feeds", page],
-    queryFn: async () => {
-      const response = await getFeeds(page);
-      return response.data;
-    },
-  });
-};
+// // 피드 전체 조회
+// export const useGetFeeds = (page: number) => {
+//   return useQuery({
+//     queryKey: ["Feeds", page],
+//     queryFn: async () => {
+//       const response = await getFeeds(page);
+//       return response.data;
+//     },
+//   });
+// };
 
 // 피드 전체 조회 (무한스크롤)
 export const useInfiniteGetFeeds = () => {

--- a/client/src/hooks/ReplyHook.ts
+++ b/client/src/hooks/ReplyHook.ts
@@ -10,13 +10,13 @@ import {
 } from "../services/replyService";
 import { queryClient } from "..";
 
-// 댓글 전체 조회
-export const useGetReplies = (feedId: number, page: number) => {
-  return useQuery({
-    queryKey: ["Replies", feedId, page],
-    queryFn: async () => getReplies(feedId, page),
-  });
-};
+// // 댓글 전체 조회
+// export const useGetReplies = (feedId: number, page: number) => {
+//   return useQuery({
+//     queryKey: ["Replies", feedId, page],
+//     queryFn: async () => getReplies(feedId, page),
+//   });
+// };
 
 // 댓글 전체 조회 (무한스크롤)
 export const useInfiniteGetReplies = (feedId: number) => {
@@ -56,6 +56,7 @@ export const usePostReply = (
     onSuccess: (res) => {
       console.log(res);
       alert("댓글 등록 완료");
+      queryClient.invalidateQueries({ queryKey: ["Feed"] });
       queryClient.invalidateQueries({ queryKey: ["Replies"] });
       successFunc && successFunc();
       return;

--- a/client/src/hooks/ReplyHook.ts
+++ b/client/src/hooks/ReplyHook.ts
@@ -19,11 +19,11 @@ import { queryClient } from "..";
 // };
 
 // 댓글 전체 조회 (무한스크롤)
-export const useInfiniteGetReplies = (feedId: number) => {
+export const useInfiniteGetReplies = (feedId: number, accesstoken: string) => {
   return useInfiniteQuery({
-    queryKey: ["Replies", feedId],
+    queryKey: ["Replies", feedId, accesstoken],
     queryFn: async ({ pageParam = 1 }) => {
-      const response = await getReplies(feedId, pageParam);
+      const response = await getReplies(feedId, accesstoken, pageParam);
       console.log("response", response);
       return response;
     },

--- a/client/src/pages/PetFeed.tsx
+++ b/client/src/pages/PetFeed.tsx
@@ -5,10 +5,13 @@ import { feedListsType } from "../types/feedDataType";
 import { ReactComponent as Pets } from "../assets/images/icons/Pets.svg";
 import { useInfiniteGetFeeds } from "../hooks/FeedHook";
 import useIntersectionObserver from "../hooks/useIntersectionObserver";
+import { useRecoilValue } from "recoil";
+import { tokenAtom } from "../atoms";
 
 const PetFeed: React.FC = () => {
+  const accesstoken = useRecoilValue(tokenAtom);
   const { data, isLoading, isError, fetchNextPage, hasNextPage } =
-    useInfiniteGetFeeds();
+    useInfiniteGetFeeds(accesstoken);
   const feedsData = data?.pages.flat();
 
   console.log(feedsData);

--- a/client/src/pages/PetFeed.tsx
+++ b/client/src/pages/PetFeed.tsx
@@ -11,6 +11,8 @@ const PetFeed: React.FC = () => {
     useInfiniteGetFeeds();
   const feedsData = data?.pages.flat();
 
+  console.log(feedsData);
+
   const { setTarget } = useIntersectionObserver({
     hasNextPage,
     fetchNextPage,

--- a/client/src/pages/PetMap.tsx
+++ b/client/src/pages/PetMap.tsx
@@ -122,11 +122,8 @@ const PetMap: React.FC = () => {
   const placesSearchCallBack = (data: any, status: any, pagination: any) => {
     if (status === kakao.maps.services.Status.OK) {
       getData(data);
-      // setPage(pagination.current);
       setTotalPage(pagination.last);
       pagination.gotoPage(isPage);
-      console.log("data", data);
-      console.log("pagination", pagination);
     } else if (status === kakao.maps.services.Status.ZERO_RESULT) {
       alertNothig();
     } else if (status === kakao.maps.services.Status.ERROR) {
@@ -172,13 +169,14 @@ const PetMap: React.FC = () => {
   };
 
   const { mutate: petMap } = usePetMap({
-    wsg84_x: location.lat,
-    wsg84_y: location.lng,
+    wgs84_x: location.lat,
+    wgs84_y: location.lng,
+    range: level * 2,
   });
 
   const getMapFeeds = useMemo(() => {
     if (!sideOpen) petMap();
-  }, [location, sideOpen]);
+  }, [location, level, sideOpen]);
 
   return (
     <PetMapContainer>

--- a/client/src/services/feedService.tsx
+++ b/client/src/services/feedService.tsx
@@ -8,8 +8,10 @@ import {
 const ROOT_URL = process.env.REACT_APP_ROOT_URL;
 
 // 피드 전체 조회
-export const getFeeds = async (page: number) => {
-  const { data } = await axios.get(`${ROOT_URL}/feed?page=${page}`);
+export const getFeeds = async (page: number, accesstoken: string) => {
+  const { data } = await axios.get(`${ROOT_URL}/feed?page=${page}`, {
+    headers: { Authorization: accesstoken },
+  });
   return data;
 };
 

--- a/client/src/services/replyService.tsx
+++ b/client/src/services/replyService.tsx
@@ -2,9 +2,16 @@ import axios from "axios";
 const ROOT_URL = process.env.REACT_APP_ROOT_URL;
 
 // 댓글 조회 // 현재 존재 x
-export const getReplies = async (feedId: number, page: number) => {
+export const getReplies = async (
+  feedId: number,
+  accesstoken: string,
+  page: number,
+) => {
   const { data } = await axios.get(
     `${ROOT_URL}/replies/feed/${feedId}?page=${page}`,
+    {
+      headers: { Authorization: accesstoken },
+    },
   );
   return data;
 };

--- a/client/src/types/mapType.tsx
+++ b/client/src/types/mapType.tsx
@@ -5,6 +5,7 @@ export type enrollMapType = {
 };
 
 export type coordinateType = {
-  wsg84_x: number;
-  wsg84_y: number;
+  wgs84_x: number;
+  wgs84_y: number;
+  range: number;
 };


### PR DESCRIPTION
## 💡 Motivation
- 1차 테스트 오류 수정 내용

## 🔑 Key Changes
전체 피드
- 좋아요, 북마크 색 변경이 안됨 => `백엔드에서 데이터 상태가 안바뀌는 것 같아요`

상세 피드
- p태그 안보이게 하기 => `수정했습니다.`

댓글
- 좋아요 색 변경 안됨 => `백엔드에서 데이터 상태가 안바뀌는 것 같아요`
- 자신의 피드 아니면 댓글 고정 버튼 안보이게 하기 => `수정했습니다.`
- 고정된 댓글이면 삭제 안됨 => `알림창 보여주기로 수정했습니다.`

대댓글
- 대댓글 입력할때 버튼으로는 전송이 안됨 => `수정했습니다.`

## 🗣️ To Reviewers
아직 몇가지 남은 오류들은 수정 중에 있습니다.
- 댓글 및 대댓글에서 설정 버튼 누를 시 드롭다운에 의해 스크롤 발생 (CSS 설정)
- 피드 전체 리스트에서 => 이미지 비디오 옆으로 스크롤 하는 버튼 작동 안함
- 피드 동영상이나 이미지가 없을 경우 출력되는 것이 오류가 남
- 펫 지도에서 특정 좌표 내에 피드 조회가 안됨